### PR TITLE
Add a macro to convert FQNs to generated target names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gmaven_rules()
 You can then reference the generated library targets from your `BUILD` files like:
 
 ```
-load("//:defs.bzl", "gmaven_artifact")
+load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
 android_library(
     ...
     deps = [

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ gmaven_rules()
 You can then reference the generated library targets from your `BUILD` files like:
 
 ```
+load("//:defs.bzl", "gmaven_artifact")
 android_library(
     ...
     deps = [
-        '@com_android_support_design_27_0_1//aar',
+        gmaven_artifact("com.android.support:design:27.0.2:aar"),
+        gmaven_artifact("com.android.support:support_annotations:27.0.2:jar"),
+        gmaven_artifact("com.android.support.test.espresso:espresso_core:3.0.1:aar"),
     ],
 )
 ```

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ load("@gmaven_rules//:defs.bzl", "gmaven_artifact")
 android_library(
     ...
     deps = [
-        gmaven_artifact("com.android.support:design:27.0.2:aar"),
-        gmaven_artifact("com.android.support:support_annotations:27.0.2:jar"),
-        gmaven_artifact("com.android.support.test.espresso:espresso_core:3.0.1:aar"),
+        gmaven_artifact("com.android.support:design:aar:27.0.2"),
+        gmaven_artifact("com.android.support:support_annotations:jar:27.0.2"),
+        gmaven_artifact("com.android.support.test.espresso:espresso_core:aar:3.0.1"),
     ],
 )
 ```

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,0 +1,23 @@
+def gmaven_artifact(fqn):
+  parts = fqn.split(":")
+  packaging = "aar"
+
+  if len(parts) < 2 or len(parts) > 5:
+    fail("Invalid qualified name for artifact: %s" % fqn)
+  elif len(parts) == 3:
+    group_id, artifact_id, version = parts
+  elif len(parts) == 4:
+    group_id, artifact_id, version, packaging = parts
+  elif len(parts) == 5:
+    _, _, _, _, classifier = parts
+    fail("Classifiers are currently not supported. Please remove it from the coordinate: %s" % classifier)
+
+  return "@%s_%s_%s//%s" % (
+        escape(group_id),
+        escape(artifact_id),
+        escape(version),
+        packaging
+      )
+
+def escape(string):
+  return string.replace(".", "_")

--- a/defs.bzl
+++ b/defs.bzl
@@ -5,9 +5,9 @@ def gmaven_artifact(fqn):
   if len(parts) == 3:
     group_id, artifact_id, version = parts
   elif len(parts) == 4:
-    group_id, artifact_id, version, packaging = parts
+    group_id, artifact_id, packaging, version = parts
   elif len(parts) == 5:
-    _, _, _, _, classifier = parts
+    _, _, _, classifier, _ = parts
     fail("Classifiers are currently not supported. Please remove it from the coordinate: %s" % classifier)
   else:
     fail("Invalid qualified name for artifact: %s" % fqn)
@@ -20,4 +20,4 @@ def gmaven_artifact(fqn):
       )
 
 def escape(string):
-  return string.replace(".", "_")
+  return string.replace(".", "_").replace("-", "_")

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,6 +1,6 @@
 def gmaven_artifact(fqn):
   parts = fqn.split(":")
-  packaging = "aar"
+  packaging = "jar"
 
   if len(parts) == 3:
     group_id, artifact_id, version = parts

--- a/defs.bzl
+++ b/defs.bzl
@@ -2,21 +2,21 @@ def gmaven_artifact(fqn):
   parts = fqn.split(":")
   packaging = "aar"
 
-  if len(parts) < 2 or len(parts) > 5:
-    fail("Invalid qualified name for artifact: %s" % fqn)
-  elif len(parts) == 3:
+  if len(parts) == 3:
     group_id, artifact_id, version = parts
   elif len(parts) == 4:
     group_id, artifact_id, version, packaging = parts
   elif len(parts) == 5:
     _, _, _, _, classifier = parts
     fail("Classifiers are currently not supported. Please remove it from the coordinate: %s" % classifier)
+  else:
+    fail("Invalid qualified name for artifact: %s" % fqn)
 
   return "@%s_%s_%s//%s" % (
-        escape(group_id),
-        escape(artifact_id),
-        escape(version),
-        packaging
+      escape(group_id),
+      escape(artifact_id),
+      escape(version),
+      packaging
       )
 
 def escape(string):


### PR DESCRIPTION
This adds `gmaven_artifact`, a convenience macro for users to directly specify the artifact's FQN. This saves users from grepping `gmaven.bzl` for target names, and mentally replace dots with underscores.