### PR TITLE
Fix License format in settings.xml

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!-- Copyright 2018 The Bazel Authors. All rights reserved. -->
 
 <!-- Licensed under the Apache License, Version 2.0 (the "License"); -->
@@ -11,7 +12,6 @@
 <!-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. -->
 <!-- See the License for the specific language governing permissions and -->
 <!-- limitations under the License. -->
-<?xml version='1.0' encoding='UTF-8'?>
 <settings
    xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
    xmlns='http://maven.apache.org/SETTINGS/1.0.0'


### PR DESCRIPTION
The license section on top of `settings.xml` was breaking the build with the following message:

> [ERROR] 1 problem was encountered while building the effective settings
> [FATAL] Non-parseable settings /home/fstephany/.cache/bazel/_bazel_fstephany/27c3a2bea20cb16a5910ae7660b43507/external/com_android_support_appcompat_v7_27_0_0/settings.xml: processing instruction can not have PITarget with reserveld xml name (position: START_DOCUMENT seen ...<!-- limitations under the License. -->\n<?xml ... @14:7)  @ /home/fstephany/.cache/bazel/_bazel_fstephany/27c3a2bea20cb16a5910ae7660b43507/external/com_android_support_appcompat_v7_27_0_0/settings.xml, line 14, column 7